### PR TITLE
go1.12 gopls cgo code jump to go-build dir no FileType syntax fixed

### DIFF
--- a/color.vim
+++ b/color.vim
@@ -1,5 +1,5 @@
 " Reverse visual mode color
-hi Visual term=reverse cterm=reverse guibg=Grey
+" hi Visual term=reverse cterm=reverse guibg=Grey
 set background=dark
 
 " coloscheme
@@ -8,3 +8,4 @@ if has('gui_running')
 end
 
 silent! colorscheme solarized
+" silent! colorscheme subtle_light

--- a/plugins.vim
+++ b/plugins.vim
@@ -13,7 +13,9 @@ let g:nerdtree_tabs_open_on_gui_startup = '1'
 " }}}
 
 " colorscheme {{{
+call dein#add('miconda/lucariox.vim')
 call dein#add('tomasr/molokai')
+call dein#add('kadekillary/subtle_solo')
 
 let g:rehash256 = 1
 
@@ -21,9 +23,13 @@ call dein#add('altercation/vim-colors-solarized')
 
 let g:solarized_termcolors = 256
 let g:solarized_termtrans  = 1
-let g:solarized_contrast   = "normal"
+let g:solarized_contrast   = "low"
 let g:solarized_visibility = "low"
+let g:solarized_bold = 1
+let g:solarized_underline = 1
+let g:solarized_italic = 1
 " }}}
+
 
 " Airline - lean & mean status/tabline for vim that's light as air {{{
 call dein#add('vim-airline/vim-airline')
@@ -64,6 +70,13 @@ au FileType go nmap <Leader>v <Plug>(go-def-vertical)
 au FileType go nmap <Leader>ii <Plug>(go-implements)
 au FileType go nmap <Leader>d <Plug>(go-doc)
 au FileType go set completeopt+=preview
+
+autocmd BufRead,BufNewFile ~/.cache/go-build/* set syntax=go
+" }}}
+
+" Python {{{
+call dein#add("davidhalter/jedi-vim")
+call dein#add("tell-k/vim-autopep8")
 " }}}
 
 " Python {{{
@@ -389,6 +402,8 @@ smap <expr><TAB> neosnippet#jumpable() ?
             \ "\<Plug>(neosnippet_jump)"
             \: "\<TAB>"
 
+let g:neosnippet#snippets_directory='~/.vim/snippets'
+
 " For snippet_complete marker.
 if has('conceal')
     set conceallevel=2 concealcursor=i
@@ -438,7 +453,7 @@ function! s:my_cr_function()
   "return pumvisible() ? "\<C-y>" : "\<CR>"
 endfunction
 " <TAB>: completion.
-inoremap <expr><TAB>  pumvisible() ? "\<C-n>" : "\<TAB>"
+" inoremap <expr><TAB>  pumvisible() ? "\<C-n>" : "\<TAB>"
 " <C-h>, <BS>: close popup and delete backword char.
 inoremap <expr><C-h> neocomplete#smart_close_popup()."\<C-h>"
 inoremap <expr><BS> neocomplete#smart_close_popup()."\<C-h>"

--- a/vimrc
+++ b/vimrc
@@ -23,6 +23,10 @@ au FileType go map <F4> :GoDef<CR>
 au FileType go map <F3> :GoDefPop<CR>
 au FileType go map <F2> :GoDefStackClear<CR>
 au FileType go map <F6> :GoDoc<CR>
+au FileType go map <F7> :GoErrCheck<CR>
+au FileType go map tt :GoAlternate<CR>
+au FileType go map <F8> :GoCoverageToggle<CR>
+au FileType go map tr :GoReferrers<CR>
 " }}}
 
 " jedi-vim som map {{{
@@ -31,8 +35,11 @@ au FileType python map <F3> <c-o>
 au FileType python map <F6> K
 " }}}
 
+
 map <F1> :NERDTreeToggle<CR>
 
-"set ttyfast
-"set lazyredraw
+set ttyfast
+set lazyredraw
+
+" cancel json file format show
 set conceallevel=0


### PR DESCRIPTION
1. Go1.12 gopls cgo code jump to go-build dir no FileType syntax fixed
2. And add some vim-go keymap.
3. Change backgound color into grey.
4. Set customized snippet dir to ~/.vim/snippets